### PR TITLE
use word size independent types

### DIFF
--- a/self_omemo.h
+++ b/self_omemo.h
@@ -52,143 +52,143 @@ size_t self_omemo_decrypt(struct GroupSession *gs,
 
 struct OlmAccount *self_olm_account(void *memory);
 
-uint64_t self_olm_account_size(void);
+size_t self_olm_account_size(void);
 
-uint64_t self_olm_create_account_random_length(struct OlmAccount *account);
+size_t self_olm_create_account_random_length(struct OlmAccount *account);
 
-uint64_t self_olm_create_account(struct OlmAccount *account, void *random, uint64_t random_length);
+size_t self_olm_create_account(struct OlmAccount *account, void *random, size_t random_length);
 
-uint64_t self_olm_import_account(struct OlmAccount *account,
-                                 void *ed25519_secret_key,
-                                 void *ed25519_public_key,
-                                 void *curve25519_secret_key,
-                                 void *curve25519_public_key);
+size_t self_olm_import_account(struct OlmAccount *account,
+                               void *ed25519_secret_key,
+                               void *ed25519_public_key,
+                               void *curve25519_secret_key,
+                               void *curve25519_public_key);
 
-uint64_t self_olm_unpickle_account(struct OlmAccount *account,
-                                   const void *key,
-                                   uint64_t key_length,
-                                   void *pickled,
-                                   uint64_t pickled_length);
-
-uint64_t self_olm_pickle_account(struct OlmAccount *account,
+size_t self_olm_unpickle_account(struct OlmAccount *account,
                                  const void *key,
-                                 uint64_t key_length,
+                                 size_t key_length,
                                  void *pickled,
-                                 uint64_t pickled_length);
+                                 size_t pickled_length);
 
-uint64_t self_olm_pickle_account_length(const struct OlmAccount *account);
+size_t self_olm_pickle_account(struct OlmAccount *account,
+                               const void *key,
+                               size_t key_length,
+                               void *pickled,
+                               size_t pickled_length);
 
-uint64_t self_olm_account_signature_length(const struct OlmAccount *account);
+size_t self_olm_pickle_account_length(const struct OlmAccount *account);
 
-uint64_t self_olm_account_sign(struct OlmAccount *account,
-                               const void *message,
-                               uint64_t message_length,
-                               void *signature,
-                               uint64_t signature_length);
+size_t self_olm_account_signature_length(const struct OlmAccount *account);
 
-uint64_t self_olm_account_max_number_of_one_time_keys(struct OlmAccount *account);
+size_t self_olm_account_sign(struct OlmAccount *account,
+                             const void *message,
+                             size_t message_length,
+                             void *signature,
+                             size_t signature_length);
 
-uint64_t self_olm_account_mark_keys_as_published(struct OlmAccount *account);
+size_t self_olm_account_max_number_of_one_time_keys(struct OlmAccount *account);
 
-uint64_t self_olm_account_generate_one_time_keys_random_length(struct OlmAccount *account,
-                                                               uint64_t number_of_keys);
+size_t self_olm_account_mark_keys_as_published(struct OlmAccount *account);
 
-uint64_t self_olm_account_generate_one_time_keys(struct OlmAccount *account,
-                                                 uint64_t number_of_keys,
-                                                 void *random,
-                                                 uint64_t random_length);
+size_t self_olm_account_generate_one_time_keys_random_length(struct OlmAccount *account,
+                                                             size_t number_of_keys);
 
-uint64_t self_olm_account_one_time_keys_length(const struct OlmAccount *account);
+size_t self_olm_account_generate_one_time_keys(struct OlmAccount *account,
+                                               size_t number_of_keys,
+                                               void *random,
+                                               size_t random_length);
 
-uint64_t self_olm_account_one_time_keys(struct OlmAccount *account,
-                                        void *one_time_keys,
-                                        uint64_t one_time_keys_length);
+size_t self_olm_account_one_time_keys_length(const struct OlmAccount *account);
 
-uint64_t self_olm_remove_one_time_keys(struct OlmAccount *account, struct OlmSession *session);
+size_t self_olm_account_one_time_keys(struct OlmAccount *account,
+                                      void *one_time_keys,
+                                      size_t one_time_keys_length);
 
-uint64_t self_olm_account_identity_keys_length(struct OlmAccount *account);
+size_t self_olm_remove_one_time_keys(struct OlmAccount *account, struct OlmSession *session);
 
-uint64_t self_olm_account_identity_keys(struct OlmAccount *account,
-                                        void *identity_keys,
-                                        uint64_t identity_key_length);
+size_t self_olm_account_identity_keys_length(struct OlmAccount *account);
 
-const int8_t *self_olm_account_last_error(const struct OlmAccount *account);
+size_t self_olm_account_identity_keys(struct OlmAccount *account,
+                                      void *identity_keys,
+                                      size_t identity_key_length);
+
+const char *self_olm_account_last_error(const struct OlmAccount *account);
 
 void self_olm_account_destroy(struct OlmAccount *account);
 
 struct OlmSession *self_olm_session(void *memory);
 
-uint64_t self_olm_session_size(void);
+size_t self_olm_session_size(void);
 
-uint64_t self_olm_create_outbound_session_random_length(const struct OlmSession *session);
+size_t self_olm_create_outbound_session_random_length(const struct OlmSession *session);
 
-uint64_t self_olm_create_outbound_session(struct OlmSession *session,
-                                          const struct OlmAccount *account,
-                                          const void *their_identity_key,
-                                          uint64_t their_identity_key_length,
-                                          const void *their_one_time_key,
-                                          uint64_t their_one_time_key_length,
-                                          void *random,
-                                          uint64_t random_length);
+size_t self_olm_create_outbound_session(struct OlmSession *session,
+                                        const struct OlmAccount *account,
+                                        const void *their_identity_key,
+                                        size_t their_identity_key_length,
+                                        const void *their_one_time_key,
+                                        size_t their_one_time_key_length,
+                                        void *random,
+                                        size_t random_length);
 
-uint64_t self_olm_create_inbound_session(struct OlmSession *session,
-                                         struct OlmAccount *account,
-                                         void *one_time_key_message,
-                                         uint64_t message_length);
+size_t self_olm_create_inbound_session(struct OlmSession *session,
+                                       struct OlmAccount *account,
+                                       void *one_time_key_message,
+                                       size_t message_length);
 
-uint64_t self_olm_create_inbound_session_from(struct OlmSession *session,
-                                              struct OlmAccount *account,
-                                              const void *their_identity_key,
-                                              uint64_t their_identity_key_length,
-                                              void *one_time_key_message,
-                                              uint64_t message_length);
+size_t self_olm_create_inbound_session_from(struct OlmSession *session,
+                                            struct OlmAccount *account,
+                                            const void *their_identity_key,
+                                            size_t their_identity_key_length,
+                                            void *one_time_key_message,
+                                            size_t message_length);
 
-uint64_t self_olm_unpickle_session(struct OlmSession *session,
-                                   const void *key,
-                                   uint64_t key_length,
-                                   void *pickled,
-                                   uint64_t pickled_length);
-
-uint64_t self_olm_pickle_session(struct OlmSession *session,
+size_t self_olm_unpickle_session(struct OlmSession *session,
                                  const void *key,
-                                 uint64_t key_length,
+                                 size_t key_length,
                                  void *pickled,
-                                 uint64_t pickled_length);
+                                 size_t pickled_length);
 
-uint64_t self_olm_pickle_session_length(const struct OlmSession *session);
+size_t self_olm_pickle_session(struct OlmSession *session,
+                               const void *key,
+                               size_t key_length,
+                               void *pickled,
+                               size_t pickled_length);
 
-uint64_t self_olm_encrypt_message_type(const struct OlmSession *session);
+size_t self_olm_pickle_session_length(const struct OlmSession *session);
 
-uint64_t self_olm_matches_inbound_session(struct OlmSession *session,
-                                          void *one_time_key_message,
-                                          uint64_t message_length);
+size_t self_olm_encrypt_message_type(const struct OlmSession *session);
 
-uint64_t self_olm_matches_inbound_session_from(struct OlmSession *session,
-                                               const void *their_identity_key,
-                                               uint64_t their_identity_key_length,
-                                               void *one_time_key_message,
-                                               uint64_t message_length);
+size_t self_olm_matches_inbound_session(struct OlmSession *session,
+                                        void *one_time_key_message,
+                                        size_t message_length);
 
-const int8_t *self_olm_session_last_error(struct OlmSession *session);
+size_t self_olm_matches_inbound_session_from(struct OlmSession *session,
+                                             const void *their_identity_key,
+                                             size_t their_identity_key_length,
+                                             void *one_time_key_message,
+                                             size_t message_length);
+
+const char *self_olm_session_last_error(struct OlmSession *session);
 
 void self_olm_session_destroy(struct OlmSession *session);
 
 int32_t self_base642bin(uint8_t *bin,
-                        uint64_t bin_maxlen,
-                        const int8_t *b64,
-                        uint64_t b64_len,
-                        const int8_t *ignore,
-                        uint64_t *bin_len,
-                        const int8_t **b64_end,
+                        size_t bin_maxlen,
+                        const char *b64,
+                        size_t b64_len,
+                        const char *ignore,
+                        size_t *bin_len,
+                        const char **b64_end,
                         int32_t variant);
 
-int8_t *self_bin2base64(int8_t *b64,
-                        uint64_t b64_maxlen,
-                        const uint8_t *bin,
-                        uint64_t bin_len,
-                        int32_t variant);
+char *self_bin2base64(char *b64,
+                      size_t b64_maxlen,
+                      const uint8_t *bin,
+                      size_t bin_len,
+                      int32_t variant);
 
-uint64_t self_base64_ENCODED_LEN(uint64_t bin_len, int32_t variant);
+size_t self_base64_ENCODED_LEN(size_t bin_len, int32_t variant);
 
 void self_crypto_aead_xchacha20poly1305_ietf_keygen(uint8_t *k);
 
@@ -218,6 +218,10 @@ int32_t self_crypto_sign_ed25519_pk_to_curve25519(uint8_t *curve25519_pk,
 int32_t self_crypto_sign_ed25519_sk_to_curve25519(uint8_t *curve25519_sk,
                                                   const uint8_t *ed25519_sk);
 
-uint64_t self_crypto_sign_publickeybytes(void);
+size_t self_crypto_sign_publickeybytes(void);
 
-void self_randombytes_buf(void *buf, uint64_t size);
+size_t self_self_crypto_sign_secretkeybytes(void);
+
+int32_t self_crypto_sign_seed_keypair(uint8_t *pk, uint8_t *sk, const uint8_t *seed);
+
+void self_randombytes_buf(void *buf, size_t size);

--- a/src/olm.rs
+++ b/src/olm.rs
@@ -1,4 +1,4 @@
-use libc::c_void;
+use libc::{c_char, c_void, size_t};
 use olm_sys::*;
 
 pub struct OlmAccount {
@@ -24,22 +24,22 @@ pub unsafe extern "C" fn self_olm_account(memory: *mut ::std::os::raw::c_void) -
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_account_size() -> u64 {
-    olm_account_size()
+pub unsafe extern "C" fn self_olm_account_size() -> size_t {
+    olm_account_size() as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_create_account_random_length(account: *mut OlmAccount) -> u64 {
-    olm_create_account_random_length((*account).ptr)
+pub unsafe extern "C" fn self_olm_create_account_random_length(account: *mut OlmAccount) -> size_t {
+    olm_create_account_random_length((*account).ptr) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_create_account(
     account: *mut OlmAccount,
     random: *mut ::std::os::raw::c_void,
-    random_length: u64,
-) -> u64 {
-    olm_create_account((*account).ptr, random, random_length)
+    random_length: size_t,
+) -> size_t {
+    olm_create_account((*account).ptr, random, random_length) as size_t
 }
 
 #[no_mangle]
@@ -49,133 +49,138 @@ pub unsafe extern "C" fn self_olm_import_account(
     ed25519_public_key: *mut ::std::os::raw::c_void,
     curve25519_secret_key: *mut ::std::os::raw::c_void,
     curve25519_public_key: *mut ::std::os::raw::c_void,
-) -> u64 {
+) -> size_t {
     olm_import_account(
         (*account).ptr,
         ed25519_secret_key,
         ed25519_public_key,
         curve25519_secret_key,
         curve25519_public_key,
-    )
+    ) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_unpickle_account(
     account: *mut OlmAccount,
     key: *const c_void,
-    key_length: u64,
+    key_length: size_t,
     pickled: *mut c_void,
-    pickled_length: u64,
-) -> u64 {
-    olm_unpickle_account((*account).ptr, key, key_length, pickled, pickled_length)
+    pickled_length: size_t,
+) -> size_t {
+    olm_unpickle_account((*account).ptr, key, key_length, pickled, pickled_length) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_pickle_account(
     account: *mut OlmAccount,
     key: *const c_void,
-    key_length: u64,
+    key_length: size_t,
     pickled: *mut c_void,
-    pickled_length: u64,
-) -> u64 {
-    olm_pickle_account((*account).ptr, key, key_length, pickled, pickled_length)
+    pickled_length: size_t,
+) -> size_t {
+    olm_pickle_account((*account).ptr, key, key_length, pickled, pickled_length) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_pickle_account_length(account: *const OlmAccount) -> u64 {
-    olm_pickle_account_length((*account).ptr)
+pub unsafe extern "C" fn self_olm_pickle_account_length(account: *const OlmAccount) -> size_t {
+    olm_pickle_account_length((*account).ptr) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_account_signature_length(account: *const OlmAccount) -> u64 {
-    olm_account_signature_length((*account).ptr)
+pub unsafe extern "C" fn self_olm_account_signature_length(account: *const OlmAccount) -> size_t {
+    olm_account_signature_length((*account).ptr) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_account_sign(
     account: *mut OlmAccount,
     message: *const ::std::os::raw::c_void,
-    message_length: u64,
+    message_length: size_t,
     signature: *mut ::std::os::raw::c_void,
-    signature_length: u64,
-) -> u64 {
+    signature_length: size_t,
+) -> size_t {
     olm_account_sign(
         (*account).ptr,
         message,
         message_length,
         signature,
         signature_length,
-    )
+    ) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_account_max_number_of_one_time_keys(
     account: *mut OlmAccount,
-) -> u64 {
-    olm_account_max_number_of_one_time_keys((*account).ptr)
+) -> size_t {
+    olm_account_max_number_of_one_time_keys((*account).ptr) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_account_mark_keys_as_published(account: *mut OlmAccount) -> u64 {
-    olm_account_mark_keys_as_published((*account).ptr)
+pub unsafe extern "C" fn self_olm_account_mark_keys_as_published(
+    account: *mut OlmAccount,
+) -> size_t {
+    olm_account_mark_keys_as_published((*account).ptr) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_account_generate_one_time_keys_random_length(
     account: *mut OlmAccount,
-    number_of_keys: u64,
-) -> u64 {
-    olm_account_generate_one_time_keys_random_length((*account).ptr, number_of_keys)
+    number_of_keys: size_t,
+) -> size_t {
+    olm_account_generate_one_time_keys_random_length((*account).ptr, number_of_keys) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_account_generate_one_time_keys(
     account: *mut OlmAccount,
-    number_of_keys: u64,
+    number_of_keys: size_t,
     random: *mut c_void,
-    random_length: u64,
-) -> u64 {
+    random_length: size_t,
+) -> size_t {
     olm_account_generate_one_time_keys((*account).ptr, number_of_keys, random, random_length)
+        as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_account_one_time_keys_length(account: *const OlmAccount) -> u64 {
-    olm_account_one_time_keys_length((*account).ptr)
+pub unsafe extern "C" fn self_olm_account_one_time_keys_length(
+    account: *const OlmAccount,
+) -> size_t {
+    olm_account_one_time_keys_length((*account).ptr) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_account_one_time_keys(
     account: *mut OlmAccount,
     one_time_keys: *mut c_void,
-    one_time_keys_length: u64,
-) -> u64 {
-    olm_account_one_time_keys((*account).ptr, one_time_keys, one_time_keys_length)
+    one_time_keys_length: size_t,
+) -> size_t {
+    olm_account_one_time_keys((*account).ptr, one_time_keys, one_time_keys_length) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_remove_one_time_keys(
     account: *mut OlmAccount,
     session: *mut OlmSession,
-) -> u64 {
-    olm_remove_one_time_keys((*account).ptr, (*session).ptr)
+) -> size_t {
+    olm_remove_one_time_keys((*account).ptr, (*session).ptr) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_account_identity_keys_length(account: *mut OlmAccount) -> u64 {
-    olm_account_identity_keys_length((*account).ptr)
+pub unsafe extern "C" fn self_olm_account_identity_keys_length(account: *mut OlmAccount) -> size_t {
+    olm_account_identity_keys_length((*account).ptr) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_account_identity_keys(
     account: *mut OlmAccount,
     identity_keys: *mut c_void,
-    identity_key_length: u64,
-) -> u64 {
-    olm_account_identity_keys((*account).ptr, identity_keys, identity_key_length)
+    identity_key_length: size_t,
+) -> size_t {
+    olm_account_identity_keys((*account).ptr, identity_keys, identity_key_length) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_account_last_error(account: *const OlmAccount) -> *const i8 {
+pub unsafe extern "C" fn self_olm_account_last_error(account: *const OlmAccount) -> *const c_char {
     olm_account_last_error((*account).ptr)
 }
 
@@ -192,15 +197,15 @@ pub unsafe extern "C" fn self_olm_session(memory: *mut c_void) -> *mut OlmSessio
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_session_size() -> u64 {
-    olm_session_size()
+pub unsafe extern "C" fn self_olm_session_size() -> size_t {
+    olm_session_size() as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_create_outbound_session_random_length(
     session: *const OlmSession,
-) -> u64 {
-    olm_create_outbound_session_random_length((*session).ptr)
+) -> size_t {
+    olm_create_outbound_session_random_length((*session).ptr) as size_t
 }
 
 #[no_mangle]
@@ -208,12 +213,12 @@ pub unsafe extern "C" fn self_olm_create_outbound_session(
     session: *mut OlmSession,
     account: *const OlmAccount,
     their_identity_key: *const c_void,
-    their_identity_key_length: u64,
+    their_identity_key_length: size_t,
     their_one_time_key: *const c_void,
-    their_one_time_key_length: u64,
+    their_one_time_key_length: size_t,
     random: *mut c_void,
-    random_length: u64,
-) -> u64 {
+    random_length: size_t,
+) -> size_t {
     olm_create_outbound_session(
         (*session).ptr,
         (*account).ptr,
@@ -223,7 +228,7 @@ pub unsafe extern "C" fn self_olm_create_outbound_session(
         their_one_time_key_length,
         random,
         random_length,
-    )
+    ) as size_t
 }
 
 #[no_mangle]
@@ -231,14 +236,14 @@ pub unsafe extern "C" fn self_olm_create_inbound_session(
     session: *mut OlmSession,
     account: *mut OlmAccount,
     one_time_key_message: *mut c_void,
-    message_length: u64,
-) -> u64 {
+    message_length: size_t,
+) -> size_t {
     olm_create_inbound_session(
         (*session).ptr,
         (*account).ptr,
         one_time_key_message,
         message_length,
-    )
+    ) as size_t
 }
 
 #[no_mangle]
@@ -246,10 +251,10 @@ pub unsafe extern "C" fn self_olm_create_inbound_session_from(
     session: *mut OlmSession,
     account: *mut OlmAccount,
     their_identity_key: *const c_void,
-    their_identity_key_length: u64,
+    their_identity_key_length: size_t,
     one_time_key_message: *mut c_void,
-    message_length: u64,
-) -> u64 {
+    message_length: size_t,
+) -> size_t {
     olm_create_inbound_session_from(
         (*session).ptr,
         (*account).ptr,
@@ -257,69 +262,69 @@ pub unsafe extern "C" fn self_olm_create_inbound_session_from(
         their_identity_key_length,
         one_time_key_message,
         message_length,
-    )
+    ) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_unpickle_session(
     session: *mut OlmSession,
     key: *const c_void,
-    key_length: u64,
+    key_length: size_t,
     pickled: *mut c_void,
-    pickled_length: u64,
-) -> u64 {
-    olm_unpickle_session((*session).ptr, key, key_length, pickled, pickled_length)
+    pickled_length: size_t,
+) -> size_t {
+    olm_unpickle_session((*session).ptr, key, key_length, pickled, pickled_length) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_pickle_session(
     session: *mut OlmSession,
     key: *const c_void,
-    key_length: u64,
+    key_length: size_t,
     pickled: *mut c_void,
-    pickled_length: u64,
-) -> u64 {
-    olm_pickle_session((*session).ptr, key, key_length, pickled, pickled_length)
+    pickled_length: size_t,
+) -> size_t {
+    olm_pickle_session((*session).ptr, key, key_length, pickled, pickled_length) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_pickle_session_length(session: *const OlmSession) -> u64 {
-    olm_pickle_session_length((*session).ptr)
+pub unsafe extern "C" fn self_olm_pickle_session_length(session: *const OlmSession) -> size_t {
+    olm_pickle_session_length((*session).ptr) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_encrypt_message_type(session: *const OlmSession) -> u64 {
-    olm_encrypt_message_type((*session).ptr)
+pub unsafe extern "C" fn self_olm_encrypt_message_type(session: *const OlmSession) -> size_t {
+    olm_encrypt_message_type((*session).ptr) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_matches_inbound_session(
     session: *mut OlmSession,
     one_time_key_message: *mut c_void,
-    message_length: u64,
-) -> u64 {
-    olm_matches_inbound_session((*session).ptr, one_time_key_message, message_length)
+    message_length: size_t,
+) -> size_t {
+    olm_matches_inbound_session((*session).ptr, one_time_key_message, message_length) as size_t
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn self_olm_matches_inbound_session_from(
     session: *mut OlmSession,
     their_identity_key: *const c_void,
-    their_identity_key_length: u64,
+    their_identity_key_length: size_t,
     one_time_key_message: *mut c_void,
-    message_length: u64,
-) -> u64 {
+    message_length: size_t,
+) -> size_t {
     olm_matches_inbound_session_from(
         (*session).ptr,
         their_identity_key,
         their_identity_key_length,
         one_time_key_message,
         message_length,
-    )
+    ) as size_t
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_olm_session_last_error(session: *mut OlmSession) -> *const i8 {
+pub unsafe extern "C" fn self_olm_session_last_error(session: *mut OlmSession) -> *const c_char {
     olm_session_last_error((*session).ptr)
 }
 

--- a/src/omemo.rs
+++ b/src/omemo.rs
@@ -76,9 +76,9 @@ impl GroupSession {
         unsafe {
             // include 16 byte validation tag
             pt_sz = sodium_base64_encoded_len(
-                (pt_len + 24) as u64,
+                pt_len + 24,
                 sodium_base64_VARIANT_ORIGINAL_NO_PADDING as i32,
-            ) as usize;
+            );
         }
 
         let pt = String::from_utf8(vec![b'X'; pt_sz]);
@@ -212,7 +212,7 @@ impl GroupSession {
             // generate some random data if needed
             if rand_sz > 0 {
                 unsafe {
-                    randombytes_buf(rand_buf.as_mut_ptr() as *mut libc::c_void, rand_sz as u64);
+                    randombytes_buf(rand_buf.as_mut_ptr() as *mut libc::c_void, rand_sz);
                 }
             }
 
@@ -237,11 +237,11 @@ impl GroupSession {
                 olm_encrypt(
                     p.session,
                     grp_pt.as_mut_ptr() as *mut libc::c_void,
-                    grp_pt.len() as u64,
+                    grp_pt.len(),
                     rand_buf.as_mut_ptr() as *mut libc::c_void,
-                    rand_sz as u64,
+                    rand_sz,
                     ct_buf.as_mut_ptr() as *mut libc::c_void,
-                    ct_sz as u64,
+                    ct_sz,
                 );
 
                 let last_err = session_error(p.session);
@@ -342,9 +342,9 @@ impl GroupSession {
             // get the size of the decrypted keys plaintext
             ptk_sz = olm_decrypt_max_plaintext_length(
                 s,
-                header.mtype as u64,
+                header.mtype as usize,
                 ctk_buf_cpy.as_mut_ptr() as *mut libc::c_void,
-                ctk_buf_cpy.len() as u64,
+                ctk_buf_cpy.len(),
             ) as size_t;
         }
 
@@ -361,11 +361,11 @@ impl GroupSession {
         unsafe {
             olm_decrypt(
                 s,
-                header.mtype as u64,
+                header.mtype as usize,
                 ctk_buf.as_mut_ptr() as *mut libc::c_void,
-                ctk_buf.len() as u64,
+                ctk_buf.len(),
                 ptk_buf.as_mut_ptr() as *mut libc::c_void,
-                ptk_sz as u64,
+                ptk_sz,
             );
         }
 

--- a/src/sodium.rs
+++ b/src/sodium.rs
@@ -1,4 +1,4 @@
-use libc::c_void;
+use libc::{c_char, c_void, size_t};
 use sodium_sys::*;
 
 pub const self_base64_VARIANT_URLSAFE: u32 = sodium_base64_VARIANT_URLSAFE;
@@ -16,12 +16,12 @@ pub const self_crypto_aead_xchacha20poly1305_ietf_KEYBYTES: u32 =
 #[no_mangle]
 pub unsafe extern "C" fn self_base642bin(
     bin: *mut u8,
-    bin_maxlen: u64,
-    b64: *const i8,
-    b64_len: u64,
-    ignore: *const i8,
-    bin_len: *mut u64,
-    b64_end: *mut *const i8,
+    bin_maxlen: size_t,
+    b64: *const c_char,
+    b64_len: size_t,
+    ignore: *const c_char,
+    bin_len: *mut size_t,
+    b64_end: *mut *const c_char,
     variant: i32,
 ) -> i32 {
     sodium_base642bin(
@@ -31,17 +31,17 @@ pub unsafe extern "C" fn self_base642bin(
 
 #[no_mangle]
 pub unsafe extern "C" fn self_bin2base64(
-    b64: *mut i8,
-    b64_maxlen: u64,
+    b64: *mut c_char,
+    b64_maxlen: size_t,
     bin: *const u8,
-    bin_len: u64,
+    bin_len: size_t,
     variant: i32,
-) -> *mut i8 {
+) -> *mut c_char {
     sodium_bin2base64(b64, b64_maxlen, bin, bin_len, variant)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_base64_ENCODED_LEN(bin_len: u64, variant: i32) -> u64 {
+pub unsafe extern "C" fn self_base64_ENCODED_LEN(bin_len: size_t, variant: i32) -> size_t {
     sodium_base64_encoded_len(bin_len, variant)
 }
 
@@ -97,11 +97,25 @@ pub unsafe extern "C" fn self_crypto_sign_ed25519_sk_to_curve25519(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_crypto_sign_publickeybytes() -> u64 {
+pub unsafe extern "C" fn self_crypto_sign_publickeybytes() -> size_t {
     crypto_sign_publickeybytes()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn self_randombytes_buf(buf: *mut c_void, size: u64) {
+pub unsafe extern "C" fn self_self_crypto_sign_secretkeybytes() -> size_t {
+    crypto_sign_secretkeybytes()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn self_crypto_sign_seed_keypair(
+    pk: *mut u8,
+    sk: *mut u8,
+    seed: *const u8,
+) -> i32 {
+    crypto_sign_seed_keypair(pk, sk, seed)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn self_randombytes_buf(buf: *mut c_void, size: size_t) {
     randombytes_buf(buf, size)
 }


### PR DESCRIPTION
- [x] add missing sodium crypto functions
- [x] use native word size independent types (`size_t`)